### PR TITLE
Changed kernel variant from "grs" to "std"

### DIFF
--- a/update-ovh-kernel.sh
+++ b/update-ovh-kernel.sh
@@ -3,7 +3,7 @@
 # Configuration
 INSTALLED_KERNEL_FILE="/etc/ovh-kernel"
 KERNEL_DIR="/boot"
-KERNEL_VARIANT="grs-ipv6-64"
+KERNEL_VARIANT="std-ipv6-64"
 KERNEL_CHANNEL="production"
 NOTIFY_REBOOT_REQUIRED_COMMAND=/usr/share/update-notifier/notify-reboot-required
 UPDATE_GRUB_COMMAND=/usr/sbin/update-grub


### PR DESCRIPTION
OVH doesn't seem to use "grs" string anymore on any kernel listed on their public ftp.