### PR TITLE
Detection of installed kernel version and soft

### DIFF
--- a/update-ovh-kernel.sh
+++ b/update-ovh-kernel.sh
@@ -10,8 +10,15 @@ UPDATE_GRUB_COMMAND=/usr/sbin/update-grub
 
 #-----------------
 
+# Install FTP client if it is not installed
+if [ ! -f /usr/bin/ftp ]; then
+    apt install ftp
+fi
+
+#-----------------
+
 # Installed kernel
-[ -r "$INSTALLED_KERNEL_FILE" ] && installed=$(cat "$INSTALLED_KERNEL_FILE") || installed="unknown"
+[ -r "$INSTALLED_KERNEL_FILE" ] && installed=$(cat "$INSTALLED_KERNEL_FILE") || installed=$(uname -r | sed 's/-.*//')
 
 # Latest kernel
 latest=$(ftp -n ftp.ovh.net<<EOF_FTP|awk -F ' -> ' '{print $2}' | sed 's/\/$//'


### PR DESCRIPTION
Command

    $(uname -r | sed 's/-.*//')

Allow to check installed version of kernel. 

For example before changes:

    Found new kernel version 4.9.78 (installed version is unknown)
    Downloading kernel v4.9.78

After changes:

    Found new kernel version 4.9.78 (installed version is 2.6.32)
    Downloading kernel v4.9.78

I also checking if ftp client if installed. If not then script install it.

Although of this I still have error

    grub-probe: error: disk `hostdisk//dev/ploop23907p1' not found.

But it is independent from changes in this commit.